### PR TITLE
fix(ios) : Update podspec to support sdk v6.5.0

### DIFF
--- a/ios/flutter_usabilla.podspec
+++ b/ios/flutter_usabilla.podspec
@@ -16,7 +16,7 @@ A Flutter wrapper for Usabilla native iOS and Android SDKs.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
-  s.dependency 'Usabilla', '~> 6.4.7'
+  s.dependency 'Usabilla', '~> 6.5'
   s.static_framework = true
   s.ios.deployment_target = '9.0'
   s.swift_version = '4.2'


### PR DESCRIPTION
Closes: [BLISS-631](https://usabilla.atlassian.net/browse/BLISS-631)

Reviewers: @usabilla/bliss

### Changelog:

## Fix
Crash on ios 13 & above , after dismissing campaign, and rotating device 

## Update
Build with Xcode 12.0 