### PR TITLE
[BUG] Removes nullable args for UsabillaFormCallback abstract funcs

### DIFF
--- a/android/src/main/kotlin/com/usabilla/flutter_usabilla/UsabillaFormCallbackImpl.kt
+++ b/android/src/main/kotlin/com/usabilla/flutter_usabilla/UsabillaFormCallbackImpl.kt
@@ -12,7 +12,7 @@ import com.usabilla.sdk.ubform.sdk.form.FormClient
 
 class UsabillaFormCallbackImpl : UsabillaFormCallback {
 
-    override fun formLoadSuccess(formClient: FormClient?) {
+    override fun formLoadSuccess(formClient: FormClient) {
         formClient?.let {
             val form = formClient.fragment
             val supportFragmentManager: FragmentManager = (activity as FragmentActivity).supportFragmentManager
@@ -20,7 +20,7 @@ class UsabillaFormCallbackImpl : UsabillaFormCallback {
         }
     }
 
-    override fun mainButtonTextUpdated(s: String?) {
+    override fun mainButtonTextUpdated(s: String) {
         val mainButtonTextArg: String = "mainButtonText"
         var result: Map<String, Any> = mapOf<String, Any>(mainButtonTextArg to s!!)
         //FIXME Need to fix mainButtonTextUpdated


### PR DESCRIPTION
Currently, on 1.0.1 version of the Flutter plugin, the
`UsabillaFormCallbackImpl` override functions that require an
argument (`formLoadSuccess` and `mainButtonTextUpdated`) accept
nullable values. However, the interface they implement does not expect
those arguments to accept nullable values any longer, as of version
7.2.0 of `com.usabilla.sdk.ubform.UsabillaFormCallback`. And, since
the build dependencies on `build.gradle` are aiming for any version of
`7.*.*`, the update to `7.2.0` in the upstream breaks the building of
the Flutter plugin; thus making it impossible to use with those
function signatures.

This commit changes the signatures of the override functions since
they are no longer needed.

**_NB_**:
We've been using the plugin often, until it stopped working because of the
above mentioned reason. While finding out what that sudden change meant
(whether broken package on pub-cache, or something else) I came across
the update to 7.2.0, hence the suggestion. 
Feedback welcome! :pray: 

Reviewers: @usabilla/bliss

### Changelog:
- Supports Usabilla SDK 7.2.0

### DoD checklist:
- [ ] Code is covered by automated tests
- [ ] Code changes are conform the platform specific coding styles
- [ ] Documentation, API changes and release notes are updated
- [ ] Manual and acceptance tests are executed when necessary


### Notes for Testing:
- 
- 

### Screenshots of visual changes:
#### Before



#### After
